### PR TITLE
ナワバリ・リーグマッチ・サーモンランの表示

### DIFF
--- a/actions/ikasuke.rb
+++ b/actions/ikasuke.rb
@@ -114,7 +114,7 @@ module Ruboty
         end_time = Time.parse(gachi_json['result'][0]['end'])
         
         body = ''
-        body << start_time.year.to_s + "年" + start_time.month.to_s + "月" + start_time.day.to_s + "日\n"
+        body << start_time.year.to_s + "年" + start_time.month.to_s + "月" + start_time.day.to_s + "日 "
         body << start_time.hour.to_s + "時 - " + end_time.hour.to_s + "時\n"
         body << "ルール : " + rule + "\nマップ : " + map1 + " / " + map2
         message.reply body
@@ -130,7 +130,7 @@ module Ruboty
         end_time = Time.parse(nawabari_json['result'][0]['end'])
 
         body = ''
-        body << start_time.year.to_s + "年" + start_time.month.to_s + "月" + start_time.day.to_s + "日\n"
+        body << start_time.year.to_s + "年" + start_time.month.to_s + "月" + start_time.day.to_s + "日 "
         body << start_time.hour.to_s + "時 - " + end_time.hour.to_s + "時\n"
         body << "ルール : " + rule + "\nマップ : " + map1 + " / " + map2
         message.reply body
@@ -146,7 +146,7 @@ module Ruboty
         end_time = Time.parse(league_json['result'][0]['end'])
 
         body = ''
-        body << start_time.year.to_s + "年" + start_time.month.to_s + "月" + start_time.day.to_s + "日\n"
+        body << start_time.year.to_s + "年" + start_time.month.to_s + "月" + start_time.day.to_s + "日 "
         body << start_time.hour.to_s + "時 - " + end_time.hour.to_s + "時\n"
         body << "ルール : " + rule + "\nマップ : " + map1 + " / " + map2
         message.reply body
@@ -165,7 +165,7 @@ module Ruboty
         map = salmon_json['result'][0]['stage']['name']
 
         body = ''
-        body << start_time.year.to_s + "年" + start_time.month.to_s + "月" + start_time.day.to_s + "日\n"
+        body << start_time.year.to_s + "年" + start_time.month.to_s + "月" + start_time.day.to_s + "日 "
         body << start_time.hour.to_s + "時 - " + end_time.hour.to_s + "時\n"
         body << "マップ : " + map + "\n"
         body << "ブキ : " + weapon_text

--- a/actions/ikasuke.rb
+++ b/actions/ikasuke.rb
@@ -128,7 +128,23 @@ module Ruboty
         map2 = nawabari_json['result'][0]['maps'][1]
         start_time = Time.parse(nawabari_json['result'][0]['start'])
         end_time = Time.parse(nawabari_json['result'][0]['end'])
-        
+
+        body = ''
+        body << start_time.year.to_s + "年" + start_time.month.to_s + "月" + start_time.day.to_s + "日\n"
+        body << start_time.hour.to_s + "時 - " + end_time.hour.to_s + "時\n"
+        body << "ルール : " + rule + "\nマップ : " + map1 + " / " + map2
+        message.reply body
+      end
+
+      def self.league_rule_map(message)
+        response = Faraday.get 'https://spla2.yuu26.com/league/now'
+        league_json = JSON.parse(response.body)
+        rule = league_json['result'][0]['rule']
+        map1 = league_json['result'][0]['maps'][0]
+        map2 = league_json['result'][0]['maps'][1]
+        start_time = Time.parse(league_json['result'][0]['start'])
+        end_time = Time.parse(league_json['result'][0]['end'])
+
         body = ''
         body << start_time.year.to_s + "年" + start_time.month.to_s + "月" + start_time.day.to_s + "日\n"
         body << start_time.hour.to_s + "時 - " + end_time.hour.to_s + "時\n"

--- a/actions/ikasuke.rb
+++ b/actions/ikasuke.rb
@@ -120,6 +120,22 @@ module Ruboty
         message.reply body
       end
 
+      def self.nawabari_rule_map(message)
+        response = Faraday.get 'https://spla2.yuu26.com/regular/now'
+        nawabari_json = JSON.parse(response.body)
+        rule = nawabari_json['result'][0]['rule']
+        map1 = nawabari_json['result'][0]['maps'][0]
+        map2 = nawabari_json['result'][0]['maps'][1]
+        start_time = Time.parse(nawabari_json['result'][0]['start'])
+        end_time = Time.parse(nawabari_json['result'][0]['end'])
+        
+        body = ''
+        body << start_time.year.to_s + "年" + start_time.month.to_s + "月" + start_time.day.to_s + "日\n"
+        body << start_time.hour.to_s + "時 - " + end_time.hour.to_s + "時\n"
+        body << "ルール : " + rule + "\nマップ : " + map1 + " / " + map2
+        message.reply body
+      end
+
     end
   end
 end

--- a/actions/ikasuke.rb
+++ b/actions/ikasuke.rb
@@ -152,6 +152,26 @@ module Ruboty
         message.reply body
       end
 
+      def self.salmon_weapon_map(message)
+        response = Faraday.get 'https://spla2.yuu26.com/coop/schedule'
+        salmon_json = JSON.parse(response.body)
+
+        weapon_list = salmon_json['result'][0]['weapons'].map {|weapon| weapon['name']}
+        weapon_text = weapon_list.join(" / ")
+
+        start_time = Time.parse(salmon_json['result'][0]['start'])
+        end_time = Time.parse(salmon_json['result'][0]['end'])
+
+        map = salmon_json['result'][0]['stage']['name']
+
+        body = ''
+        body << start_time.year.to_s + "年" + start_time.month.to_s + "月" + start_time.day.to_s + "日\n"
+        body << start_time.hour.to_s + "時 - " + end_time.hour.to_s + "時\n"
+        body << "マップ : " + map + "\n"
+        body << "ブキ : " + weapon_text
+        message.reply body
+      end
+
     end
   end
 end

--- a/handlers/ikasuke.rb
+++ b/handlers/ikasuke.rb
@@ -4,6 +4,7 @@ module Ruboty
       on /brand (?<brand_name>.*?)\z/, name: 'brand', description: 'ブランド毎に付きやすい/付きにくいギア出力', all: true
       on /gpower (?<gpower_name>.*?)\z/, name: 'gpower', description: 'ギア名から付きやすいブランドを出力', all: true
       on /gachi/, name: 'gachi', description: '現在のガチマッチのルールとマップを出力', all: true
+      on /nawabari/, name: 'nawabari', description: '現在のナワバリバトルのルールとマップを出力', all: true
 
       # ブランド名からギア詳細出力
       def brand(message)
@@ -28,6 +29,10 @@ module Ruboty
       # 現在のガチマッチのマップとルールを出力
       def gachi(message)
         Ruboty::Actions::Ikasuke.gachi_rule_map(message)
+      end
+
+      def nawabari(message)
+        Ruboty::Actions::Ikasuke.nawabari_rule_map(message)
       end
 
     end

--- a/handlers/ikasuke.rb
+++ b/handlers/ikasuke.rb
@@ -5,6 +5,7 @@ module Ruboty
       on /gpower (?<gpower_name>.*?)\z/, name: 'gpower', description: 'ギア名から付きやすいブランドを出力', all: true
       on /gachi/, name: 'gachi', description: '現在のガチマッチのルールとマップを出力', all: true
       on /nawabari/, name: 'nawabari', description: '現在のナワバリバトルのルールとマップを出力', all: true
+      on /league/, name: 'league', description: '現在のリーグマッチのルールとマップを出力', all: true
 
       # ブランド名からギア詳細出力
       def brand(message)
@@ -31,8 +32,14 @@ module Ruboty
         Ruboty::Actions::Ikasuke.gachi_rule_map(message)
       end
 
+      # 現在のナワバリバトルのマップとルールを出力
       def nawabari(message)
         Ruboty::Actions::Ikasuke.nawabari_rule_map(message)
+      end
+
+      # 現在のリーグマッチのマップとルールを出力
+      def league(message)
+        Ruboty::Actions::Ikasuke.league_rule_map(message)
       end
 
     end

--- a/handlers/ikasuke.rb
+++ b/handlers/ikasuke.rb
@@ -43,6 +43,7 @@ module Ruboty
         Ruboty::Actions::Ikasuke.league_rule_map(message)
       end
 
+      # 現在または直近のサーモンランのマップとブキを出力
       def salmon(message)
         Ruboty::Actions::Ikasuke.salmon_weapon_map(message)
       end

--- a/handlers/ikasuke.rb
+++ b/handlers/ikasuke.rb
@@ -6,6 +6,7 @@ module Ruboty
       on /gachi/, name: 'gachi', description: '現在のガチマッチのルールとマップを出力', all: true
       on /nawabari/, name: 'nawabari', description: '現在のナワバリバトルのルールとマップを出力', all: true
       on /league/, name: 'league', description: '現在のリーグマッチのルールとマップを出力', all: true
+      on /salmon/, name: 'salmon', description: '直近あるいは現在のブキとマップを出力', all: true
 
       # ブランド名からギア詳細出力
       def brand(message)
@@ -40,6 +41,10 @@ module Ruboty
       # 現在のリーグマッチのマップとルールを出力
       def league(message)
         Ruboty::Actions::Ikasuke.league_rule_map(message)
+      end
+
+      def salmon(message)
+        Ruboty::Actions::Ikasuke.salmon_weapon_map(message)
       end
 
     end


### PR DESCRIPTION
## 概要
ナワバリバトルとサーモンランとリーグマッチの情報をバハムートに表示させる

## 修正理由
https://github.com/unasuke/bot-bahamut/issues/19
ガチマッチしか実装されてないため

## 詳細
ガチマ同様にマップと時間とルールおよびブキ情報を取得、整形、出力
