### PR TITLE
サーモンランに終了日時を追加する

### DIFF
--- a/actions/ikasuke.rb
+++ b/actions/ikasuke.rb
@@ -165,8 +165,8 @@ module Ruboty
         map = salmon_json['result'][0]['stage']['name']
 
         body = ''
-        body << start_time.year.to_s + "年" + start_time.month.to_s + "月" + start_time.day.to_s + "日 "
-        body << start_time.hour.to_s + "時 - " + end_time.hour.to_s + "時\n"
+        body << start_time.year.to_s + "年" + start_time.month.to_s + "月" + start_time.day.to_s + "日" + start_time.hour.to_s + "時 - "
+        body << end_time.year.to_s + "年" + end_time.month.to_s + "月" + end_time.day.to_s + "日" + end_time.hour.to_s + "時\n"
         body << "マップ : " + map + "\n"
         body << "ブキ : " + weapon_text
         message.reply body


### PR DESCRIPTION
## 概要
サーモンランの終了時間のうち、`時`しかなかったので
終わりの日時を追加する

## 変更理由
https://github.com/unasuke/bot-bahamut/issues/19
終わりの時間を忘れてたため

## 詳細
終わりの時間を持ってきて整形、追加した