### PR TITLE
gpower listが長すぎるので無駄なハイフンを消す

### DIFF
--- a/actions/ikasuke.rb
+++ b/actions/ikasuke.rb
@@ -90,8 +90,7 @@ module Ruboty
       def self.gearpower_list(message)
         body = ''
         GPOWER_LIST.each do |key, value|
-          body << "-------------------------\n"
-          body << "#{key} が付きやすいブランドは #{value}\n"
+          body << "#{key} が付きやすいブランドは #{value}\n\n"
         end
         message.reply body
       end


### PR DESCRIPTION
https://github.com/unasuke/bot-bahamut/issues/57
ハイフンだけで1行26文字食ってるので改行だけにする