### PR TITLE
会話履歴の保存に対応

### DIFF
--- a/actions/ai_reply.rb
+++ b/actions/ai_reply.rb
@@ -1,6 +1,7 @@
 require 'anthropic'
 require_relative '../lib/ruboty/patches/discord_typing' unless ENV['LOCAL']
 require_relative '../lib/tool_handlers/memories'
+require_relative '../lib/conversation_history'
 
 module Ruboty
   module Actions
@@ -21,8 +22,13 @@ module Ruboty
       def call(body)
         typing_thread = start_typing_loop
 
+        channel_id = message.original[:from]
+        @history = ConversationHistory.new(channel_id)
+        @history_log = []
+
         user_content = "#{message.from_name || 'anonymous'}: #{body}"
-        messages = [{ role: 'user', content: user_content }]
+        @history_log << { role: 'user', content: user_content }
+        messages = @history.load + [{ role: 'user', content: user_content }]
 
         run_agentic_loop(messages)
       rescue Anthropic::Errors::APIError => e
@@ -94,8 +100,15 @@ module Ruboty
             # Resume paused turn (e.g. long-running web search)
             messages << { role: 'assistant', content: serialize_content(response.content) }
           else
+            assistant_text = response.content
+              .select { |b| b.type == :text }
+              .map(&:text)
+              .join
+            @history_log << { role: 'assistant', content: assistant_text } unless assistant_text.empty?
+
             send_urls_message(collected_urls)
             send_code_message(collected_codes)
+            @history.save(@history_log)
             return
           end
         end

--- a/lib/conversation_history.rb
+++ b/lib/conversation_history.rb
@@ -1,0 +1,46 @@
+require 'json'
+require 'fileutils'
+
+class ConversationHistory
+  DEFAULT_DIR = '/var/bot-bahamut/history'
+  MAX_MESSAGES = 10
+  EXPIRY_SECONDS = 3600
+
+  def initialize(channel_id)
+    @dir = ENV.fetch('HISTORY_DIR', DEFAULT_DIR)
+    @path = File.join(@dir, "#{channel_id}.json")
+    FileUtils.mkdir_p(@dir)
+  end
+
+  def load
+    return [] unless File.exist?(@path)
+
+    cutoff = Time.now.to_i - EXPIRY_SECONDS
+    load_raw
+      .select { |e| e[:timestamp] >= cutoff }
+      .last(MAX_MESSAGES)
+      .map { |e| e[:message] }
+  rescue JSON::ParserError
+    []
+  end
+
+  def save(messages)
+    now = Time.now.to_i
+    cutoff = now - EXPIRY_SECONDS
+
+    existing = load_raw.select { |e| e[:timestamp] >= cutoff }
+    new_entries = messages.map { |m| { timestamp: now, message: m } }
+
+    merged = (existing + new_entries).last(MAX_MESSAGES * 2)
+    File.write(@path, JSON.generate(merged))
+  end
+
+  private
+
+  def load_raw
+    return [] unless File.exist?(@path)
+    JSON.parse(File.read(@path), symbolize_names: true)
+  rescue JSON::ParserError
+    []
+  end
+end


### PR DESCRIPTION
Closes #92

チャンネルごとに会話履歴をJSONファイルで保存し、次回のメンション時に直近の会話をcontextとして渡すようにしました。

- 環境変数 `HISTORY_DIR` で指定したディレクトリ配下に `{channel_id}.json` として保存（省略時: `/var/bot-bahamut/history`）
- 直近1時間以内かつ最大10件に絞って渡す
- APIに渡す `messages` と履歴保存用の `@history_log` を分離し、tool_useブロック等は履歴に含めない

**Note:** デプロイ等で必要な設定（ボリュームマウントなど）はしていないので、適宜対応してください。