### PR TITLE
docs: HISTORY_DIR 環境変数をドキュメントに追記

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -46,6 +46,7 @@ Dockerfile           # Ruby 4.0.2ベースのコンテナ
 - `ANTHROPIC_MODEL` - 使用するモデル (省略時: `claude-haiku-4-5`)
 - `LOCAL` - 設定するとDiscordアダプタ・typing表示をスキップ (ローカル開発用)
 - `MEMORIES_DIR` - memoryツールの保存先 (省略時: `/var/bot-bahamut/memories`)
+- `HISTORY_DIR` - 会話履歴の保存先 (省略時: `/var/bot-bahamut/history`)
 - `REMINDERS_DB_PATH` - リマインダー用SQLiteデータベースのパス (省略時: `/var/bot-bahamut/db/reminders.db`)
 
 ## ローカル実行

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 | `ANTHROPIC_MODEL` | 使用するモデル（省略時: `claude-haiku-4-5`） |
 | `LOCAL` | 設定するとDiscord接続を無効化しローカル開発用モードで動作する（Discordアダプタの読み込み、typing表示をスキップ） |
 | `MEMORIES_DIR` | memoryツールの保存先（省略時: `/var/bot-bahamut/memories`） |
+| `HISTORY_DIR` | 会話履歴の保存先（省略時: `/var/bot-bahamut/history`） |
 | `REMINDERS_DB_PATH` | リマインダー用SQLiteデータベースのパス（省略時: `/var/bot-bahamut/db/reminders.db`） |
 
 ## ローカルで実行する方法


### PR DESCRIPTION
会話履歴機能追加時に漏れていた `HISTORY_DIR` 環境変数の説明を `README.md` と `.claude/CLAUDE.md` に追記します。