### PR TITLE
システムプロンプトの日時を JST に固定する

### DIFF
--- a/actions/ai_reply.rb
+++ b/actions/ai_reply.rb
@@ -63,7 +63,7 @@ module Ruboty
           response = client.messages.create(
             model: MODEL,
             max_tokens: MAX_TOKENS,
-            system: "#{SYSTEM_PROMPT}\n現在の日時: #{Time.now.strftime('%Y-%m-%d %H:%M:%S %Z')}",
+            system: "#{SYSTEM_PROMPT}\n現在の日時: #{Time.now.getlocal('+09:00').strftime('%Y-%m-%d %H:%M:%S JST')}",
             tools: tools,
             messages: messages
           )


### PR DESCRIPTION
環境のタイムゾーン設定に依存していたため、デプロイ環境（UTC）では日時が UTC で表示されていました。`getlocal('+09:00')` で JST に固定します。